### PR TITLE
Provide javadoc for configuration attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,2 +1,6 @@
+# 0.0.3 ....
+
+- javadoc on configuration attributes (IDE tooltips)
+
 # 0.0.2 (2017-12-01)
 - [NEW] Initial release

--- a/cloudant-spring-boot-starter/src/main/java/com/ibm/cloudant/spring/boot/CloudantConfigurationProperties.java
+++ b/cloudant-spring-boot-starter/src/main/java/com/ibm/cloudant/spring/boot/CloudantConfigurationProperties.java
@@ -20,12 +20,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix="cloudant")
 public class CloudantConfigurationProperties {
 
+    /** URL for cloudant service. This URL should not include the username or password. **/
     private URL url;
     
+    /** Cloudant username */
     private String username;
 
+    /** Cloudant password */ 
     private String password;
 
+    /** Cloudant database */
     private String db;
 
     public void setUrl(URL url) {


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/java-cloudant/blob/master/DCO1.1.txt)
- [ ] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant-labs/cloudant-spring/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

Added Javadoc for configuration properties

## How

These properties will/should provide tooltips in STS to help with configuration

## Testing

Documentation only. 

## Issues

Links to the github issue(s) (if present) that this pull request is resolving.
