### PR TITLE
Add spring config gen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # 0.0.3 (UNRELEASED)
 - [IMPROVED] javadoc on configuration attributes (IDE tooltips).
+- [IMPROVED] Added Spring configuration meta-data for improved IDE context help
 
 # 0.0.2 (2017-12-01)
 - [NEW] Initial release.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # 0.0.3 (UNRELEASED)
 - [IMPROVED] javadoc on configuration attributes (IDE tooltips).
-- [IMPROVED] Added Spring configuration meta-data for improved IDE context help
+- [IMPROVED] Added Spring configuration meta-data for improved IDE context help.
 
 # 0.0.2 (2017-12-01)
 - [NEW] Initial release.

--- a/cloudant-spring-boot-starter/build.gradle
+++ b/cloudant-spring-boot-starter/build.gradle
@@ -12,7 +12,23 @@
  * and limitations under the License.
  */
 
+
+apply plugin: 'propdeps'
+apply plugin: 'propdeps-maven'
+
+buildscript {
+    repositories {
+        maven { url 'http://repo.spring.io/plugins-release' }
+    }
+    dependencies {
+        classpath 'io.spring.gradle:propdeps-plugin:0.0.9.RELEASE'
+    }
+}
+
 dependencies {
   compile group: 'org.springframework.boot', name: 'spring-boot', version: springBootVersion
   compile group: 'org.springframework.boot', name: 'spring-boot-autoconfigure', version: springBootVersion
+  optional group: 'org.springframework.boot', name: 'spring-boot-configuration-processor', version: springBootVersion
 }
+
+compileJava.dependsOn(processResources)


### PR DESCRIPTION
Signed-off-by: Katherine Stanley <katheris@uk.ibm.com>

Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/java-cloudant/blob/master/DCO1.1.txt)
- [ ] You have added tests for any code changes - Not applicable
- [x] You have updated the [CHANGES.md](https://github.com/cloudant-labs/cloudant-spring/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

Add a [configuration meta-data](https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html) file.

## How

Update build.gradle file for cloudant-spring-boot-starter project to auto-generate a configuration meta-data file from the classes annotated with `@ConfigurationProperties`.

## Testing

Verified that when running the build the new file is created and has the correct content.

## Issues
N/A
