### PR TITLE
Added createDb option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [NEW] Configuration option `cloudant.createDb` for creating the database. Can be disabled to allow
+ use of a legacy API key.
+
 # 0.0.3 (2018-06-13)
 - [IMPROVED] javadoc on configuration attributes (IDE tooltips).
 - [IMPROVED] Added Spring configuration meta-data for improved IDE context help.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The library is split into two parts:
 Gradle:
 ```groovy
 dependencies {
-    compile group: 'com.cloudant', name: 'cloudant-spring-boot-starter', version: '0.0.1'
+    compile group: 'com.cloudant', name: 'cloudant-spring-boot-starter', version: '0.0.3'
 }
 ```
 
@@ -34,7 +34,7 @@ Maven:
 <dependency>
   <groupId>com.cloudant</groupId>
   <artifactId>cloudant-spring-boot-starter</artifactId>
-  <version>0.0.1</version>
+  <version>0.0.3</version>
 </dependency>
 ~~~
 
@@ -43,7 +43,7 @@ Maven:
 Gradle:
 ```groovy
 dependencies {
-    compile group: 'com.cloudant', name: 'cloudant-spring-framework', version: '0.0.1'
+    compile group: 'com.cloudant', name: 'cloudant-spring-framework', version: '0.0.3'
 }
 ```
 
@@ -52,7 +52,7 @@ Maven:
 <dependency>
   <groupId>com.cloudant</groupId>
   <artifactId>cloudant-spring-framework</artifactId>
-  <version>0.0.1</version>
+  <version>0.0.3</version>
 </dependency>
 ~~~
 
@@ -103,6 +103,19 @@ private Database db;
 public List<Greeting> getAllDocsAsGreetings() {
     return List<Greeting> allDocs = db.getAllDocsRequestBuilder().includeDocs(true).build().getResponse().getDocsAs(Greeting.class);
 }
+~~~
+
+By default the database specified by `cloudant.db` will be created if it doesn't exist. You can
+change this behaviour with the `cloudant.createDb` configuration property. This is useful in cases
+where the supplied credentials don't have permission to create a database, such as when using a
+legacy API key. For example:
+
+~~~
+cloudant.url=http://cloudant.com
+cloudant.username=myCloudanLegacyAPIKey
+cloudant.password=myKeyPassphrase
+cloudant.db=myDb
+cloudant.createDb=false
 ~~~
 
 To provide custom connection options you can override the `com.cloudant.client.api.ClientBuilder` bean and provide your own properties:
@@ -187,7 +200,7 @@ The preferred approach for using cloudant-spring in other projects is to use the
 
 ### License
 
-Copyright © 2017 IBM Corp. All rights reserved.
+Copyright © 2017, 2018 IBM Corp. All rights reserved.
 
 Licensed under the apache license, version 2.0 (the "license"); you may not use this file except in compliance with the license.  you may obtain a copy of the license at
 

--- a/cloudant-spring-boot-starter/src/main/java/com/ibm/cloudant/spring/boot/CloudantAutoConfiguration.java
+++ b/cloudant-spring-boot-starter/src/main/java/com/ibm/cloudant/spring/boot/CloudantAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 IBM Corp. All rights reserved.
+ * Copyright © 2017, 2018 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -51,7 +51,7 @@ public class CloudantAutoConfiguration {
     @Bean
     @ConditionalOnProperty(name = "cloudant.db")
     public Database database(CloudantClient client) {
-        Database db = client.database(config.getDb(), true);
+        Database db = client.database(config.getDb(), config.getCreateDb());
         return db;
     }
 }

--- a/cloudant-spring-boot-starter/src/main/java/com/ibm/cloudant/spring/boot/CloudantConfigurationProperties.java
+++ b/cloudant-spring-boot-starter/src/main/java/com/ibm/cloudant/spring/boot/CloudantConfigurationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 IBM Corp. All rights reserved.
+ * Copyright © 2017, 2018 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -14,8 +14,9 @@
 
 package com.ibm.cloudant.spring.boot;
 
-import java.net.URL;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.net.URL;
 
 @ConfigurationProperties(prefix="cloudant")
 public class CloudantConfigurationProperties {
@@ -31,6 +32,11 @@ public class CloudantConfigurationProperties {
 
     /** Cloudant database */
     private String db;
+
+    /** Create the named Cloudant database if it doesn't exist.
+     * Must be false if using a legacy API key.
+     */
+    private boolean createDb = true;
 
     public void setUrl(URL url) {
         this.url = url;
@@ -48,6 +54,10 @@ public class CloudantConfigurationProperties {
         this.db = db;
     }
 
+    public void setCreateDb(boolean createDb) {
+        this.createDb = createDb;
+    }
+
     public URL getUrl() {
         return this.url;
     }
@@ -62,6 +72,10 @@ public class CloudantConfigurationProperties {
 
     public String getDb() {
         return this.db;
+    }
+
+    public boolean getCreateDb() {
+        return this.createDb;
     }
 
 }

--- a/cloudant-spring-boot-starter/src/test/java/com/cloudant/spring/boot/test/AutoConfigurationTest.java
+++ b/cloudant-spring-boot-starter/src/test/java/com/cloudant/spring/boot/test/AutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 IBM Corp. All rights reserved.
+ * Copyright © 2017, 2018 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -16,23 +16,23 @@ package com.cloudant.spring.boot.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.cloudant.client.api.ClientBuilder;
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
+import com.ibm.cloudant.spring.boot.CloudantAutoConfiguration;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.core.SpringVersion;
 import org.springframework.boot.SpringBootVersion;
 import org.springframework.boot.test.util.EnvironmentTestUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import com.ibm.cloudant.spring.boot.CloudantAutoConfiguration;
+import org.springframework.core.SpringVersion;
 
 public class AutoConfigurationTest {
 
@@ -93,6 +93,20 @@ public class AutoConfigurationTest {
         this.context.register(MockCloudantClientConfig.class, MockClientBuilderConfig.class,
             CloudantAutoConfiguration.class);
         EnvironmentTestUtils.addEnvironment(this.context, "cloudant.db=testName");
+        this.context.refresh();
+        Database db = this.context.getBean(Database.class);
+        assertEquals(mockDb, db);
+    }
+
+    @Test
+    public void databaseBeanCreationWithCreateFalse() {
+        Database mockDb = mock(Database.class);
+        when(mockBuilder.build()).thenReturn(mockClient);
+        when(mockClient.database("testName", false)).thenReturn(mockDb);
+
+        this.context.register(MockCloudantClientConfig.class, MockClientBuilderConfig.class,
+                CloudantAutoConfiguration.class);
+        EnvironmentTestUtils.addEnvironment(this.context, "cloudant.db=testName", "cloudant.createDb=false");
         this.context.refresh();
         Database db = this.context.getBean(Database.class);
         assertEquals(mockDb, db);


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

When using a legacy API key for credentials the default option of attempting to create the database is invalid. Provide a new configuration option `createDb` to allow for disabling the creation.

Fixes #12

## Approach

Added new configuration property `cloudant.createDb` defaulting to `true`.
Updated README for new property and updated example versions.

## Schema & API Changes

New configuration option `createDb` defaults to `true` maintaining backwards compatibility.

## Security and Privacy

- "No change"

## Testing

- Added new tests:
    - `com.cloudant.spring.boot.test.AutoConfigurationTest#databaseBeanCreationWithCreateFalse`

## Monitoring and Logging

- "No change"
