### PR TITLE
Update java-cloudant to 2.19.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [UPGRADED] java-cloudant dependency to version 2.19.1.
+
 # 0.0.4 (2018-11-08)
 - [NEW] Configuration option `cloudant.createDb` for creating the database. Can be disabled to allow
  use of a legacy API key.

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ subprojects {
   
   dependencies {
     // java-cloudant client
-    compile group: 'com.cloudant', name: 'cloudant-client', version: '2.13.0'
+    compile group: 'com.cloudant', name: 'cloudant-client', version: '2.19.1'
     // spring
     compile group: 'org.springframework', name: 'spring-core', version: compileWithSpringVersion
     compile group: 'org.springframework', name: 'spring-context', version: compileWithSpringVersion

--- a/cloudant-spring-boot-starter/build.gradle
+++ b/cloudant-spring-boot-starter/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'propdeps-maven'
 
 buildscript {
     repositories {
-        maven { url 'http://repo.spring.io/plugins-release' }
+        maven { url 'https://repo.spring.io/plugins-release' }
     }
     dependencies {
         classpath 'io.spring.gradle:propdeps-plugin:0.0.9.RELEASE'


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] build only - Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Update java-cloudant to `2.19.1`
- Fix spring repo link to use https
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
