### PR TITLE
577 tag based releases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Release Notes
+
+For releases from version 0.2.7 onwards, please see the [GitHub Releases page](https://github.com/IBM/cloudant-spring/releases).
+
+---
+
 # 0.2.6 (2026-03-24)
 - [UPGRADED] Spring Boot compilation version to `3.5.12`.
 - [UPGRADED] `com.ibm.cloud:cloudant` to `0.10.16`.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,10 +44,6 @@ def gradlePublish = {
   }
 }
 
-def prefixlessTag(tag) {
-    return tag.replaceFirst('v','')
-}
-
 pipeline {
   agent {
     kubernetes {
@@ -147,11 +143,11 @@ pipeline {
         }
       }
       steps {
-        script {
-          gitsh('github.com') {
+        gitsh('github.com') {
+          script {
             bumpVersion(params.TARGET_VERSION)
-            sh 'git push --tags origin HEAD:main'
           }
+          sh 'git push --tags origin HEAD:main'
         }
       }
     }
@@ -161,43 +157,43 @@ pipeline {
       when {
         allOf {
           buildingTag()
-          tag pattern: /${env.SVRE_PRE_RELEASE_TAG}/, comparator: 'REGEXP'
+          tag pattern: /v${env.SVRE_RELEASE}/, comparator: "REGEXP"
         }
       }
       steps {
         script {
           gradlePublish()
-          // Upload from OSSRH staging API to central portal and publish
-          httpRequest(
-            authentication: 'central-portal',
-            httpMode: 'POST',
-            responseHandle: 'NONE',
-            url: 'https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.ibm.cloud?publishing_type=automatic',
-            validResponseCodes: '200',
-            wrapAsMultipart: false
-          )
-
-          httpRequest(
-            authentication: 'gh-sdks-automation',
-            contentType: 'APPLICATION_JSON_UTF8',
-            customHeaders: [[name: 'Accept', value: 'application/vnd.github+json']],
-            httpMode: 'POST',
-            outputFile: 'release_response.json',
-            requestBody: """
-              {
-                "tag_name": "${TAG_NAME}",
-                "name": "${prefixlessTag(TAG_NAME)} (${new Date(TAG_TIMESTAMP as long).format('yyyy-MM-dd')})",
-                "draft": false,
-                "prerelease": false,
-                "generate_release_notes": true
-              }
-              """.stripIndent(),
-            timeout: 60,
-            url: 'https://api.github.com/repos/IBM/cloudant-spring/releases',
-            validResponseCodes: '201',
-            wrapAsMultipart: false
-          )
         }
+        // Upload from OSSRH staging API to central portal and publish
+        httpRequest(
+          authentication: 'central-portal',
+          httpMode: 'POST',
+          responseHandle: 'NONE',
+          url: 'https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.ibm.cloud?publishing_type=automatic',
+          validResponseCodes: '200',
+          wrapAsMultipart: false
+        )
+
+        httpRequest(
+          authentication: 'gh-sdks-automation',
+          contentType: 'APPLICATION_JSON_UTF8',
+          customHeaders: [[name: 'Accept', value: 'application/vnd.github+json']],
+          httpMode: 'POST',
+          outputFile: 'release_response.json',
+          requestBody: """
+            {
+              "tag_name": "${TAG_NAME}",
+              "name": "${TAG_NAME.replaceFirst('v','')} (${new Date(TAG_TIMESTAMP as long).format('yyyy-MM-dd')})",
+              "draft": false,
+              "prerelease": false,
+              "generate_release_notes": true
+            }
+            """.stripIndent(),
+          timeout: 60,
+          url: 'https://api.github.com/repos/IBM/cloudant-spring/releases',
+          validResponseCodes: '201',
+          wrapAsMultipart: false
+        )
       }
       post {
         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,19 +14,38 @@
  * and limitations under the License.
  */
 
-def getNewVersion = { isDevRelease ->
+def getDevVersion = {
   targetVersion = sh(returnStdout: true, script: 'bump-my-version show-bump --ascii | grep patch | rev | cut -f1 -d " " | rev').trim()
-  if (isDevRelease) return targetVersion + '-SNAPSHOT'
-  return targetVersion
+  return targetVersion + '-SNAPSHOT'
 }
 
 def doVersionBump = { isDevRelease, newVersion ->
   sh "bump-my-version bump patch --new-version ${newVersion} ${isDevRelease ? '--no-commit' : '--tag --tag-message \"Release {new_version}\"'}"
 }
 
-def bumpVersion = { isDevRelease ->
-  newVersion = getNewVersion(isDevRelease)
-  doVersionBump(isDevRelease, newVersion)
+def bumpVersion = { version ->
+  isDevRelease = version.contains('-SNAPSHOT')
+  doVersionBump(isDevRelease, version)
+}
+
+def gradlePublish = {
+  withCredentials([usernamePassword(credentialsId: 'central-portal', passwordVariable: 'CP_PASSWORD', usernameVariable: 'CP_USER'), 
+                  certificate(credentialsId: 'cldtsdks-signing-cert', keystoreVariable: 'CODE_SIGNING_PFX_FILE', passwordVariable: 'CODE_SIGNING_P12_PASSWORD')]) {
+    sh '''
+      #!/bin/bash -e
+      # Configure the signing client
+      setup-garasign-client
+      # Get the key ID
+      SIGNING_KEYID=$(grep 'Key ID' $HOME/.gnupggrs/keysinfo.txt | awk 'NR==1{print $5}')
+      # Do a gradle publish that signs and uploads using the OSSRH creds
+      # upload destination logic is in build.gradle
+      gradle -Psigning.gnupg.keyName=$SIGNING_KEYID -Psigning.gnupg.executable=/opt/Garantir/bin/gpg -Psigning.gnupg.homeDir=$HOME/.gnupggrs publish
+    '''
+  }
+}
+
+def prefixlessTag(tag) {
+    return tag.replaceFirst('v','')
 }
 
 pipeline {
@@ -34,6 +53,13 @@ pipeline {
     kubernetes {
       yaml kubePodTemplate(name: 'full_jnlp.yaml')
     }
+  }
+  parameters {
+    validatingString( name: 'TARGET_VERSION',
+                      defaultValue: 'NONE',
+                      description: 'Tag to create after successful QA',
+                      failedValidationMessage: 'Tag name must be NONE or a semantic version release or pre-release (i.e. no build metadata)',
+                      regex: /NONE|${globals.SVRE_PRE_RELEASE}/)
   }
   environment {
     ARTIFACTORY_CREDS = credentials('artifactory')
@@ -90,13 +116,17 @@ pipeline {
 
     stage('Publish[staging]') {
       when {
+        allOf {
+          expression { env.BRANCH_IS_PRIMARY }
           not {
-              buildingTag()
+            buildingTag()
           }
+        }
       }
       steps {
         script {
-          bumpVersion(true)
+          bumpVersion(getDevVersion())
+          gradlePublish()
         }
       }
       post {
@@ -106,47 +136,65 @@ pipeline {
       }
     }
 
+    stage('Update version and tag') {
+      when {
+        beforeAgent true
+        allOf {
+          expression { env.BRANCH_IS_PRIMARY }
+          not {
+            equals expected: 'NONE', actual: "${params.TARGET_VERSION}"
+          }
+        }
+      }
+      steps {
+        gitsh('github.com') {
+          bumpVersion(params.TARGET_VERSION)
+          sh 'git push --tags origin HEAD:main'
+        }
+      }
+    }
+
     // Publish the primary branch
     stage('Publish') {
+      when {
+        allOf {
+          buildingTag()
+          tag pattern: /${env.SVRE_PRE_RELEASE_TAG}/, comparator: 'REGEXP'
+        }
+      }
       steps {
         script {
-          if (env.BRANCH_IS_PRIMARY) {
-            // read the version name and determine if it is a release build
-            version = sh(returnStdout: true, script: 'bump-my-version show current_version').trim()
-            isReleaseVersion = !version.toUpperCase(Locale.ENGLISH).contains("SNAPSHOT")
+          gradlePublish()
+          // Upload from OSSRH staging API to central portal and publish
+          httpRequest(
+            authentication: 'central-portal',
+            httpMode: 'POST',
+            responseHandle: 'NONE',
+            url: 'https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.ibm.cloud?publishing_type=automatic',
+            validResponseCodes: '200',
+            wrapAsMultipart: false
+          )
 
-            withCredentials([usernamePassword(credentialsId: 'central-portal', passwordVariable: 'CP_PASSWORD', usernameVariable: 'CP_USER'), 
-                            certificate(credentialsId: 'cldtsdks-signing-cert', keystoreVariable: 'CODE_SIGNING_PFX_FILE', passwordVariable: 'CODE_SIGNING_P12_PASSWORD')]) {
-              sh '''
-                #!/bin/bash -e
-                # Configure the signing client
-                setup-garasign-client
-                # Get the key ID
-                SIGNING_KEYID=$(grep 'Key ID' $HOME/.gnupggrs/keysinfo.txt | awk 'NR==1{print $5}')
-                # Do a gradle publish that signs and uploads using the OSSRH creds
-                # upload destination logic is in build.gradle
-                gradle -Psigning.gnupg.keyName=$SIGNING_KEYID -Psigning.gnupg.executable=/opt/Garantir/bin/gpg -Psigning.gnupg.homeDir=$HOME/.gnupggrs publish
-              '''
-            }
-            // if it is a release build then do extra work
-            if (isReleaseVersion) {
-              // Upload from OSSRH staging API to central portal and publish
-              httpRequest(
-                authentication: 'central-portal',
-                httpMode: 'POST',
-                responseHandle: 'NONE',
-                url: 'https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.ibm.cloud?publishing_type=automatic',
-                validResponseCodes: '200',
-                wrapAsMultipart: false
-              )
-
-              // Create a git tag and a draft release
-              gitTagAndPublish {
-                isDraft=true
-                releaseApiUrl='https://api.github.com/repos/IBM/cloudant-spring/releases'
+          httpRequest(
+            authentication: 'gh-sdks-automation',
+            contentType: 'APPLICATION_JSON_UTF8',
+            customHeaders: [[name: 'Accept', value: 'application/vnd.github+json']],
+            httpMode: 'POST',
+            outputFile: 'release_response.json',
+            requestBody: """
+              {
+                "tag_name": "${TAG_NAME}",
+                "name": "${prefixlessTag(TAG_NAME)} (${new Date(TAG_TIMESTAMP as long).format('yyyy-MM-dd')})",
+                "draft": false,
+                "prerelease": false,
+                "generate_release_notes": true
               }
-            }
-          }
+              """.stripIndent(),
+            timeout: 60,
+            url: 'https://api.github.com/repos/IBM/cloudant-spring/releases',
+            validResponseCodes: '201',
+            wrapAsMultipart: false
+          )
         }
       }
       post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,9 +147,11 @@ pipeline {
         }
       }
       steps {
-        gitsh('github.com') {
-          bumpVersion(params.TARGET_VERSION)
-          sh 'git push --tags origin HEAD:main'
+        script {
+          gitsh('github.com') {
+            bumpVersion(params.TARGET_VERSION)
+            sh 'git push --tags origin HEAD:main'
+          }
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [ ] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->
Release cloudant-spring from tags

Fixes i577
## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

- Add build parameter TARGET_VERSION
- Add "Update version and tag" stage that runs when TARGET_VERSION is set, which calls `bumpVersion()` with the parameter value and pushes the created commit/tag
- Extract gradle publish logic into reusable `gradlePublish()` function
- Refactor `bumpVersion()` to accept version parameter and auto-detect dev vs release builds
- Publish[staging] runs on main branch builds, auto-calculates snapshot version and calls `gradlePublish()`
- Publish stage runs when building tags and creates GitHub release
- Remove `gitTagAndPublish`
- Update `CHANGES.md` to direct users to GitHub Releases page for future release notes

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->
- "No change"
## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->
- "No change"
## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

- N/A build or packaging only changes
## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
- "No change"