### PR TITLE
fix: replace mock with explicit Mockito.mock()

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-springBootVersion = "4.0.7"
+springBootVersion = "4.1.0"
 
 [libraries]
 cloudant = { module = "com.ibm.cloud:cloudant", version = "0.10.19" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-springBootVersion = "3.5.15"
+springBootVersion = "4.0.7"
 
 [libraries]
 cloudant = { module = "com.ibm.cloud:cloudant", version = "0.10.19" }

--- a/src/test/java/unit/ConfigurationTest.java
+++ b/src/test/java/unit/ConfigurationTest.java
@@ -18,7 +18,6 @@ import com.ibm.cloud.cloudant.internal.CloudantFactory;
 import com.ibm.cloud.cloudant.v1.Cloudant;
 import com.ibm.cloud.cloudant.spring.boot.CloudantAutoConfiguration;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -59,8 +58,7 @@ class ConfigurationTest {
     @Autowired
     CloudantFactory serviceFactory;
 
-    @Mock
-    Cloudant cloudant;
+    Cloudant cloudant = Mockito.mock(Cloudant.class);
 
     @Test
     void testSetUrl() {


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [ ] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [ ] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->
Fix `NullPointerException` on `ConfigurationTest`
## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->
Replaced `@Mock` with explicit `Mockito.mock()` call.
## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->
- "No change"
## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->
- "No change"
## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->
- Modified existing `ConfigurationTest` to prevent `NullPointerException`.
## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
- "No change"