### PR TITLE
ci: unify junit versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 springBootVersion = "4.1.0"
+junitVersion = "6.1.1"
 
 [libraries]
 cloudant = { module = "com.ibm.cloud:cloudant", version = "0.10.19" }
@@ -7,8 +8,8 @@ spring-boot = { module = "org.springframework.boot:spring-boot", version.ref = "
 spring-boot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure", version.ref = "springBootVersion" }
 spring-boot-configuration-processor = { module = "org.springframework.boot:spring-boot-configuration-processor", version.ref = "springBootVersion" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springBootVersion" }
-junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version = "6.1.1" }
-junitPlatformLauncher = { module = "org.junit.platform:junit-platform-launcher", version = "6.1.1" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junitVersion" }
+junitPlatformLauncher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitVersion" }
 mockito-core = { module = "org.mockito:mockito-core", version = "5.23.0" }
 
 [bundles]


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Unify junit dependency versions

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue

https://github.com/IBM/cloudant-spring/blob/c7909fb81cfb90d76ee9d389237acab5d816acc2/gradle/libs.versions.toml#L10-L11

### 2. What you expected to happen

In JUnit 6.x (and I think even 5.x) the published modules share a single version number.

### 3. What actually happened

Current gradle versions file independently versions the `junit-jupiter` and `junitPlatformLauncher` dependencies.

## Approach

To reduce the number of update PRs and keep the junit modules in lock-step:

* Add `junitVersion` to `[versions]`
* ref it with `version.ref = "junitVersion"`

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"


## Testing

- N/A build or packaging only changes - build is green

## Monitoring and Logging

- "No change"
